### PR TITLE
Add cleaned fragments file to Registry table

### DIFF
--- a/wf/__init__.py
+++ b/wf/__init__.py
@@ -73,7 +73,8 @@ metadata = LatchMetadata(
         ),
         "table_id": LatchParameter(
             display_name="Registry Table ID",
-            description="Provide the ID of the Registry table. The cleaned fragment file will be populated in the table once the workflow finishes."
+            description="Provide the ID of the Registry table. The cleaned fragment file will be populated in the table once the workflow finishes. (e.g. 390)",
+            placeholder="390"
         )
     },
     tags=[],
@@ -87,7 +88,7 @@ def clean_workflow(
     positions_file: LatchFile,
     fragments_file: LatchFile,
     deviations: int=1,
-    table_id: str="390"
+    table_id: str = "390"
 ) -> LatchFile:
     """Workflow for normalizing hot rows and columns in spatial ATAC-seq data
 

--- a/wf/__init__.py
+++ b/wf/__init__.py
@@ -71,6 +71,10 @@ metadata = LatchMetadata(
             which row/column medians will be considered outliers.",
             batch_table_column=True, 
         ),
+        "table_id": LatchParameter(
+            display_name="Registry Table ID",
+            description="Provide the ID of the Registry table. The cleaned fragment file will be populated in the table once the workflow finishes."
+        )
     },
     tags=[],
 
@@ -83,6 +87,7 @@ def clean_workflow(
     positions_file: LatchFile,
     fragments_file: LatchFile,
     deviations: int=1,
+    table_id: str="390"
 ) -> LatchFile:
     """Workflow for normalizing hot rows and columns in spatial ATAC-seq data
 
@@ -116,7 +121,11 @@ def clean_workflow(
         deviations=deviations
     )
 
-    upload_registry_task(run_id=run_id, cleaned_fragment_file=cleaned_fragment_file)
+    upload_registry_task(
+        run_id=run_id, 
+        cleaned_fragment_file=cleaned_fragment_file, 
+        table_id=table_id
+    )
 
     return cleaned_fragment_file
 


### PR DESCRIPTION
- I accidentally pushed the Registry table insert code to main, but it should be very similar to the PR I made for the spatial ATAC-seq workflow!
- Goal is to add the cleaned fragment file to Registry table. You can check out the example table ["Runs"](https://console.latch.bio/registry)